### PR TITLE
*: Update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: |
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     services:
       tidb4:
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -44,12 +44,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox tox-gh-actions
+          sudo apt-get update
           sudo apt-get install -y libmemcached-dev zlib1g-dev
 
       - name: Run tests
         run: tox
         env:
-          DJANGO_VERSION: 3.2.12
+          DJANGO_VERSION: 3.2.18
 
   django4_tidb4:
     name: Python ${{ matrix.python-version }} | Django 4 | TiDB 4
@@ -67,10 +68,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -83,7 +84,7 @@ jobs:
       - name: Run tests
         run: tox
         env:
-          DJANGO_VERSION: 4.0.3
+          DJANGO_VERSION: 4.0.10
 
   django3_tidb5:
     name: Python ${{ matrix.python-version }} | Django 3 | TiDB 5
@@ -91,7 +92,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     services:
       tidb5:
@@ -101,10 +102,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -117,7 +118,7 @@ jobs:
       - name: Run tests
         run: tox
         env:
-          DJANGO_VERSION: 3.2.12
+          DJANGO_VERSION: 3.2.18
 
   django4_tidb5:
     name: Python ${{ matrix.python-version }} | Django 4 | TiDB 5
@@ -135,10 +136,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -151,4 +152,4 @@ jobs:
       - name: Run tests
         run: tox
         env:
-          DJANGO_VERSION: 4.0.3
+          DJANGO_VERSION: 4.0.10

--- a/django_test_suite.sh
+++ b/django_test_suite.sh
@@ -23,6 +23,7 @@ mkdir -p $DJANGO_TESTS_DIR
 pip3 install .
 git clone --depth 1  --branch $DJANGO_VERSION https://github.com/django/django.git $DJANGO_TESTS_DIR/django
 cp tidb_settings.py $DJANGO_TESTS_DIR/django/tidb_settings.py
+cp tidb_settings.py $DJANGO_TESTS_DIR/django/tests/tidb_settings.py
 
 cd $DJANGO_TESTS_DIR/django && pip3 install -e . && pip3 install -r tests/requirements/py3.txt && pip3 install -r tests/requirements/mysql.txt; cd ../../
 cd $DJANGO_TESTS_DIR/django/tests

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -58,7 +58,7 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
         if self.connection.tidb_version >= (6, 2, 0):
             return True
         return False
-    
+
     @cached_property
     def can_release_savepoints(self):
         if self.connection.tidb_version >= (6, 2, 0):

--- a/tox.ini
+++ b/tox.ini
@@ -13,11 +13,10 @@
 
 [tox]
 alwayscopy=true
-envlist = py310,py39,py38,py37,py36,lint
+envlist = py310,py39,py38,py37,lint
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39
@@ -33,6 +32,6 @@ setenv =
 [testenv:lint]
 skip_install = True
 deps =
-  flake8==3.9.2
+  flake8==6.0.0
 commands =
   flake8 django_tidb


### PR DESCRIPTION
Minimal update

## Including

- Moving from `actions/checkout@v2` to `actions/checkout@v3`
- Moving from `actions/setup-python@v2` to `actions/setup-python@v4`
- Removing Python 3.6
- Updating to the latest Django 3.2 and 4.0 versions
- Moving from flake8 3.9.2 to 6.0.0

## Excluding

- Moving from Django 4.0 to Django 4.1
- Moving to newer TiDB versions