### PR TITLE
Change from Django 4.0 to Django 4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Run tests
         run: tox
         env:
-          DJANGO_VERSION: 4.0.10
+          DJANGO_VERSION: 4.1.7
 
   django3_tidb5:
     name: Python ${{ matrix.python-version }} | Django 3 | TiDB 5
@@ -152,4 +152,4 @@ jobs:
       - name: Run tests
         run: tox
         env:
-          DJANGO_VERSION: 4.0.10
+          DJANGO_VERSION: 4.1.7

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ SECRET_KEY = 'django_tests_secret_key'
 ## Supported versions
 
 - TiDB 4.0 and newer
-- Django 3.2 and 4.0
+- Django 3.2 and 4.1
 - Python 3.6 and newer(must match Django's Python version requirement)
 
 ## Test

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -384,6 +384,17 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                     'constraints.tests.CheckConstraintTests.test_database_constraint_expressionwrapper',
                 }
             })
+        if django.utils.version.get_complete_version() >= (4, 1):
+            skips.update({
+                'django41': {
+                    'migrations.test_operations.OperationTests.test_create_model_with_boolean_expression_in_check_constraint',
+                    'migrations.test_operations.OperationTests.test_remove_func_unique_constraint',
+                    'migrations.test_operations.OperationTests.test_remove_func_index',
+                    'migrations.test_operations.OperationTests.test_alter_field_with_func_index',
+                    'migrations.test_operations.OperationTests.test_add_func_unique_constraint',
+                    'migrations.test_operations.OperationTests.test_add_func_index',
+                }
+            })
         return skips
 
     @cached_property

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -109,10 +109,6 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 'file_uploads.tests.DirectoryCreationTests.test_readonly_root',
                 'cache.tests.CacheMiddlewareTest.test_cache_page_timeout',
 
-                # RuntimeError: A durable atomic block cannot be nested within another atomic block.
-                'transactions.tests.DisableDurabiltityCheckTests.test_nested_both_durable',
-                'transactions.tests.DisableDurabiltityCheckTests.test_nested_inner_durable',
-
                 # wrong test result
                 '.test_no_duplicates_for_non_unique_related_object_in_search_fields',
                 'transaction_hooks.tests.TestConnectionOnCommit.test_inner_savepoint_does_not_affect_outer',
@@ -383,6 +379,10 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                     'schema.tests.SchemaTests.test_alter_autofield_pk_to_smallautofield_pk_sequence_owner',
 
                     'test_utils.test_testcase.TestDataTests.test_undeepcopyable_warning',
+
+                    # RuntimeError: A durable atomic block cannot be nested within another atomic block.
+                    'transactions.tests.DisableDurabiltityCheckTests.test_nested_both_durable',
+                    'transactions.tests.DisableDurabiltityCheckTests.test_nested_inner_durable',
                 }
             })
         if django.utils.version.get_complete_version() >= (4, 1):
@@ -403,6 +403,9 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                     'schema.tests.SchemaTests.test_autofield_to_o2o',
                     'schema.tests.SchemaTests.test_func_index_lookups',
                     'schema.tests.SchemaTests.test_func_unique_constraint_lookups',
+
+                    'update.tests.AdvancedTests.test_update_ordered_by_inline_m2m_annotation',
+                    'update.tests.AdvancedTests.test_update_ordered_by_m2m_annotation',
                 }
             })
         return skips

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -222,8 +222,6 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
 
                 # IntegrityError not raised
                 'constraints.tests.CheckConstraintTests.test_database_constraint',
-                'constraints.tests.CheckConstraintTests.test_database_constraint_expression',
-                'constraints.tests.CheckConstraintTests.test_database_constraint_expressionwrapper',
                 'constraints.tests.CheckConstraintTests.test_database_constraint_unicode',
 
                 # Cannot assign "<Book: Book object (90)>": the current database router prevents this relation.
@@ -379,6 +377,13 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
             })
         if self.connection.tidb_version >= (4, 0, 5) and self.connection.tidb_version <= (4, 0, 9):
             skips['tidb4'].add('lookup.tests.LookupTests.test_regex')
+        if django.utils.version.get_complete_version() < (4, 1):
+            skips.update({
+                'django40': {
+                    'constraints.tests.CheckConstraintTests.test_database_constraint_expression',
+                    'constraints.tests.CheckConstraintTests.test_database_constraint_expressionwrapper',
+                }
+            })
         return skips
 
     @cached_property

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -210,6 +210,7 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
 
                 'backends.base.test_base.ExecuteWrapperTests.test_nested_wrapper_invoked',
                 'backends.base.test_base.ExecuteWrapperTests.test_outer_wrapper_blocks',
+                'backends.tests.BackendTestCase.test_queries_limit',
                 'backends.tests.FkConstraintsTests.test_check_constraints',
                 'backends.tests.FkConstraintsTests.test_check_constraints_sql_keywords',
 

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -151,9 +151,6 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 # Unsupported modify column: can't remove auto_increment without @@tidb_allow_remove_auto_inc enabled
                 'schema.tests.SchemaTests.test_alter_auto_field_to_integer_field',
 
-                # 'Unsupported modify column: this column has primary key flag
-                'schema.tests.SchemaTests.test_alter_autofield_pk_to_smallautofield_pk_sequence_owner',
-
                 # Found wrong number (0) of check constraints for schema_author.height
                 'schema.tests.SchemaTests.test_alter_field_default_dropped',
 
@@ -382,6 +379,9 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 'django40': {
                     'constraints.tests.CheckConstraintTests.test_database_constraint_expression',
                     'constraints.tests.CheckConstraintTests.test_database_constraint_expressionwrapper',
+
+                    # 'Unsupported modify column: this column has primary key flag
+                    'schema.tests.SchemaTests.test_alter_autofield_pk_to_smallautofield_pk_sequence_owner',
                 }
             })
         if django.utils.version.get_complete_version() >= (4, 1):
@@ -393,6 +393,15 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                     'migrations.test_operations.OperationTests.test_alter_field_with_func_index',
                     'migrations.test_operations.OperationTests.test_add_func_unique_constraint',
                     'migrations.test_operations.OperationTests.test_add_func_index',
+
+                    'schema.tests.SchemaTests.test_add_auto_field',
+                    'schema.tests.SchemaTests.test_add_field_o2o_nullable',
+                    'schema.tests.SchemaTests.test_alter_autofield_pk_to_smallautofield_pk',
+                    'schema.tests.SchemaTests.test_alter_primary_key_db_collation',
+                    'schema.tests.SchemaTests.test_alter_primary_key_the_same_name',
+                    'schema.tests.SchemaTests.test_autofield_to_o2o',
+                    'schema.tests.SchemaTests.test_func_index_lookups',
+                    'schema.tests.SchemaTests.test_func_unique_constraint_lookups',
                 }
             })
         return skips

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -295,7 +295,6 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
 
                 # https://code.djangoproject.com/ticket/33633#ticket
                 # once supports_transactions is True, could be opened; same as below
-                'test_utils.test_testcase.TestDataTests.test_undeepcopyable_warning',
                 'test_utils.test_testcase.TestDataTests.test_class_attribute_identity',
                 'test_utils.tests.CaptureOnCommitCallbacksTests.test_execute',
                 'test_utils.tests.CaptureOnCommitCallbacksTests.test_no_arguments',
@@ -382,6 +381,8 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
 
                     # 'Unsupported modify column: this column has primary key flag
                     'schema.tests.SchemaTests.test_alter_autofield_pk_to_smallautofield_pk_sequence_owner',
+
+                    'test_utils.test_testcase.TestDataTests.test_undeepcopyable_warning',
                 }
             })
         if django.utils.version.get_complete_version() >= (4, 1):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
         'Framework :: Django :: 3.2',
-        'Framework :: Django :: 4.0',
+        'Framework :: Django :: 4.1',
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',

--- a/tidb_settings.py
+++ b/tidb_settings.py
@@ -24,24 +24,24 @@ if port is None:
 DATABASES = {
     'default': {
         'ENGINE': 'django_tidb',
-        'NAME': 'django_tests',
         'USER': 'root',
         'PASSWORD': '',
         'HOST': '127.0.0.1',
         'PORT': 4000,
         'TEST': {
+            'NAME': 'django_tests',
             'CHARSET': 'utf8mb4',
             'COLLATION': 'utf8mb4_general_ci',
         },
     },
     'other': {
         'ENGINE': 'django_tidb',
-        'NAME': 'django_tests2',
         'USER': 'root',
         'PASSWORD': '',
         'HOST': hosts,
         'PORT': port,
         'TEST': {
+            'NAME': 'django_tests2',
             'CHARSET': 'utf8mb4',
             'COLLATION': 'utf8mb4_general_ci',
         },

--- a/tox.ini
+++ b/tox.ini
@@ -34,4 +34,4 @@ skip_install = True
 deps =
   flake8==6.0.0
 commands =
-  flake8 django_tidb
+  flake8 --max-line-length 130 django_tidb


### PR DESCRIPTION
Update the Django version to match the upstream release/support schedule

From  https://www.djangoproject.com/download/ 

![image](https://user-images.githubusercontent.com/1272980/225566097-edee5b8d-8a45-46c2-b2b5-3940792683c6.png)


- https://docs.djangoproject.com/en/4.1/releases/4.1/
- https://docs.djangoproject.com/en/4.1/ref/settings/#test