### PR TITLE
CI: Add Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     services:
       tidb4:
@@ -126,7 +126,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     services:
       tidb5:

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     install_requires=["mysqlclient"],
     project_urls={

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 passenv = *


### PR DESCRIPTION
Only for Django 4.1 as Django 3.2 doesn't support Python 3.11

![image](https://user-images.githubusercontent.com/1272980/225861487-a64d5f74-fc36-4ee4-a4e8-fab989580667.png)


https://docs.djangoproject.com/en/3.2/releases/3.2/#python-compatibility