### PR TITLE
feat: support django v4.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ SECRET_KEY = 'django_tests_secret_key'
 ## Supported versions
 
 - TiDB 4.0 and newer
-- Django 3.2 and 4.1
+- Django 3.2, 4.1 and 4.2
 - Python 3.6 and newer(must match Django's Python version requirement)
 
 ## Test

--- a/django_tidb/base.py
+++ b/django_tidb/base.py
@@ -40,6 +40,9 @@ class DatabaseWrapper(MysqlDatabaseWrapper):
     introspection_class = DatabaseIntrospection
     ops_class = DatabaseOperations
 
+    def get_database_version(self):
+        return self.tidb_version
+
     @cached_property
     def data_type_check_constraints(self):
         if self.features.supports_column_check_constraints:

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -279,7 +279,7 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 "test_utils.tests.TestBadSetUpTestData.test_failure_in_setUpTestData_should_rollback_transaction",
             },
         }
-        if django.VERSION > (3,):
+        if django.VERSION[0] > 3:
             skips.update(
                 {
                     "django4": {

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -404,15 +404,16 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                     }
                 }
             )
-        if "ONLY_FULL_GROUP_BY" in self.connection.sql_mode:
-            skips.update(
-                {
-                    "GROUP BY cannot contain nonaggregated column when "
-                    "ONLY_FULL_GROUP_BY mode is enabled on TiDB.": {
-                        "aggregation.tests.AggregateTestCase.test_group_by_nested_expression_with_params",
-                    },
-                }
-            )
+        if django.utils.version.get_complete_version() >= (4, 2):
+            if "ONLY_FULL_GROUP_BY" in self.connection.sql_mode:
+                skips.update(
+                    {
+                        "GROUP BY cannot contain nonaggregated column when "
+                        "ONLY_FULL_GROUP_BY mode is enabled on TiDB.": {
+                            "aggregation.tests.AggregateTestCase.test_group_by_nested_expression_with_params",
+                        },
+                    }
+                )
         return skips
 
     @cached_property

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -34,6 +34,8 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
         "non_default": "utf8mb4_bin",
     }
 
+    minimum_database_version = (4, )
+
     @cached_property
     def supports_foreign_keys(self):
         if self.connection.tidb_version >= (6, 6, 0):
@@ -90,7 +92,6 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 "aggregation_regress.tests.AggregationTests.test_more_more",
                 "aggregation_regress.tests.JoinPromotionTests.test_ticket_21150",
                 "annotations.tests.NonAggregateAnnotationTestCase.test_annotation_aggregate_with_m2o",
-                "defer_regress.tests.DeferAnnotateSelectRelatedTest.test_defer_annotate_select_related",
                 "queries.test_explain.ExplainTests",
                 "queries.test_qs_combinators.QuerySetSetOperationTests."
                 "test_union_with_values_list_and_order_on_annotation",
@@ -146,8 +147,6 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 "schema.tests.SchemaTests.test_alter_not_unique_field_to_primary_key",
                 # Unsupported modify column: can't set auto_increment
                 "schema.tests.SchemaTests.test_alter_smallint_pk_to_smallautofield_pk",
-                # BLOB/TEXT/JSON column 'address' can't have a default value
-                "schema.tests.SchemaTests.test_alter_text_field_to_not_null_with_default_value",
                 # Unsupported modify column: this column has primary key flag
                 "schema.tests.SchemaTests.test_char_field_pk_to_auto_field",
                 # Unsupported modify charset from utf8mb4 to utf8
@@ -156,6 +155,17 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 "schema.tests.SchemaTests.test_primary_key",
                 # wrong result
                 "schema.tests.SchemaTests.test_alter_pk_with_self_referential_field",
+                # Unsupported add foreign key reference to themselves
+                "schema.tests.SchemaTests.test_add_inline_fk_update_data",
+                # This testcase is designed for MySQL only
+                "schema.tests.SchemaTests.test_add_foreign_key_quoted_db_table",
+                # Unsupported add column and foreign key in single statement
+                # https://github.com/pingcap/tidb/issues/45474
+                "schema.tests.SchemaTests.test_add_foreign_key_long_names",
+                # Ditto
+                "schema.tests.SchemaTests.test_unique_together_with_fk_with_existing_index",
+                # Ditto
+                "schema.tests.SchemaTests.test_add_inline_fk_index_update_data",
                 "schema.tests.SchemaTests.test_db_table",
                 "schema.tests.SchemaTests.test_indexes",
                 "schema.tests.SchemaTests.test_inline_fk",
@@ -220,6 +230,16 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 "migrations.test_operations.OperationTests.test_rename_field_reloads_state_on_fk_target_changes",
                 "migrations.test_operations.OperationTests.test_smallfield_autofield_foreignfield_growth",
                 "migrations.test_operations.OperationTests.test_smallfield_bigautofield_foreignfield_growth",
+                # Unsupported modifying the Reorg-Data types on the primary key
+                "migrations.test_operations.OperationTests.test_alter_field_pk_fk",
+                # Ditto
+                "migrations.test_operations.OperationTests.test_alter_field_pk_fk_char_to_int",
+                # Unsupported modifying collation of column from 'utf8mb4_general_ci' to 'utf8mb4_bin'
+                # when index is defined on it.
+                "migrations.test_operations.OperationTests.test_alter_field_pk_fk_db_collation",
+                # Unsupported add column and foreign key in single statement
+                # https://github.com/pingcap/tidb/issues/45474
+                "migrations.test_operations.OperationTests.test_remove_fk",
                 "migrations.test_loader.RecorderTests.test_apply",
                 "migrations.test_commands.MigrateTests.test_migrate_fake_initial",
                 "migrations.test_commands.MigrateTests.test_migrate_initial_false",
@@ -259,7 +279,7 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 "test_utils.tests.TestBadSetUpTestData.test_failure_in_setUpTestData_should_rollback_transaction",
             },
         }
-        if int(django.__version__[0]) > 3:
+        if django.VERSION > (3, ):
             skips.update(
                 {
                     "django4": {
@@ -274,6 +294,15 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                         "test_utils.test_testcase.TestTestCase.test_reset_sequences",
                         "test_utils.tests.CaptureOnCommitCallbacksTests.test_execute_recursive",
                         "test_utils.tests.CaptureOnCommitCallbacksTests.test_execute_tree",
+                    }
+                }
+            )
+        if django.VERSION < (4, 2):
+            skips.update(
+                {
+                    "django4.1": {
+                        # removed after Django 4.1
+                        "defer_regress.tests.DeferAnnotateSelectRelatedTest.test_defer_annotate_select_related",
                     }
                 }
             )
@@ -375,6 +404,15 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                     }
                 }
             )
+        if "ONLY_FULL_GROUP_BY" in self.connection.sql_mode:
+            skips.update(
+                {
+                    "GROUP BY cannot contain nonaggregated column when "
+                    "ONLY_FULL_GROUP_BY mode is enabled on TiDB.": {
+                        "aggregation.tests.AggregateTestCase.test_group_by_nested_expression_with_params",
+                    },
+                }
+            )
         return skips
 
     @cached_property
@@ -383,6 +421,8 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
 
     @cached_property
     def can_introspect_foreign_keys(self):
+        if self.connection.tidb_version >= (6, 6, 0):
+            return True
         return False
 
     @cached_property

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -232,8 +232,6 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 "migrations.test_operations.OperationTests.test_smallfield_bigautofield_foreignfield_growth",
                 # Unsupported modifying the Reorg-Data types on the primary key
                 "migrations.test_operations.OperationTests.test_alter_field_pk_fk",
-                # Ditto
-                "migrations.test_operations.OperationTests.test_alter_field_pk_fk_char_to_int",
                 # Unsupported modifying collation of column from 'utf8mb4_general_ci' to 'utf8mb4_bin'
                 # when index is defined on it.
                 "migrations.test_operations.OperationTests.test_alter_field_pk_fk_db_collation",
@@ -405,6 +403,14 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 }
             )
         if django.utils.version.get_complete_version() >= (4, 2):
+            skips.update(
+                {
+                    "django42": {
+                        # Unsupported modifying the Reorg-Data types on the primary key
+                        "migrations.test_operations.OperationTests.test_alter_field_pk_fk_char_to_int",
+                    }
+                }
+            )
             if "ONLY_FULL_GROUP_BY" in self.connection.sql_mode:
                 skips.update(
                     {

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -34,7 +34,7 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
         "non_default": "utf8mb4_bin",
     }
 
-    minimum_database_version = (4, )
+    minimum_database_version = (4,)
 
     @cached_property
     def supports_foreign_keys(self):
@@ -279,7 +279,7 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 "test_utils.tests.TestBadSetUpTestData.test_failure_in_setUpTestData_should_rollback_transaction",
             },
         }
-        if django.VERSION > (3, ):
+        if django.VERSION > (3,):
             skips.update(
                 {
                     "django4": {

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -232,9 +232,6 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 "migrations.test_operations.OperationTests.test_smallfield_bigautofield_foreignfield_growth",
                 # Unsupported modifying the Reorg-Data types on the primary key
                 "migrations.test_operations.OperationTests.test_alter_field_pk_fk",
-                # Unsupported modifying collation of column from 'utf8mb4_general_ci' to 'utf8mb4_bin'
-                # when index is defined on it.
-                "migrations.test_operations.OperationTests.test_alter_field_pk_fk_db_collation",
                 # Unsupported add column and foreign key in single statement
                 # https://github.com/pingcap/tidb/issues/45474
                 "migrations.test_operations.OperationTests.test_remove_fk",
@@ -399,6 +396,9 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                         "schema.tests.SchemaTests.test_func_unique_constraint_lookups",
                         "update.tests.AdvancedTests.test_update_ordered_by_inline_m2m_annotation",
                         "update.tests.AdvancedTests.test_update_ordered_by_m2m_annotation",
+                        # Unsupported modifying collation of column from 'utf8mb4_general_ci' to 'utf8mb4_bin'
+                        # when index is defined on it.
+                        "migrations.test_operations.OperationTests.test_alter_field_pk_fk_db_collation",
                     }
                 }
             )

--- a/django_tidb/introspection.py
+++ b/django_tidb/introspection.py
@@ -21,7 +21,8 @@ from django.db.models import Index
 from django.utils.datastructures import OrderedSet
 
 FieldInfo = namedtuple(
-    "FieldInfo", BaseFieldInfo._fields + ("extra", "is_unsigned", "has_json_constraint", "comment")
+    "FieldInfo",
+    BaseFieldInfo._fields + ("extra", "is_unsigned", "has_json_constraint", "comment"),
 )
 InfoLine = namedtuple(
     "InfoLine",

--- a/django_tidb/introspection.py
+++ b/django_tidb/introspection.py
@@ -21,12 +21,12 @@ from django.db.models import Index
 from django.utils.datastructures import OrderedSet
 
 FieldInfo = namedtuple(
-    "FieldInfo", BaseFieldInfo._fields + ("extra", "is_unsigned", "has_json_constraint")
+    "FieldInfo", BaseFieldInfo._fields + ("extra", "is_unsigned", "has_json_constraint", "comment")
 )
 InfoLine = namedtuple(
     "InfoLine",
     "col_name data_type max_len num_prec num_scale extra column_default "
-    "collation is_unsigned",
+    "collation is_unsigned comment",
 )
 
 
@@ -81,7 +81,8 @@ class DatabaseIntrospection(MysqlDatabaseIntrospection):
                 CASE
                     WHEN column_type LIKE '%% unsigned' THEN 1
                     ELSE 0
-                END AS is_unsigned
+                END AS is_unsigned,
+                column_comment
             FROM information_schema.columns
             WHERE table_name = %s AND table_schema = DATABASE()
         """,
@@ -101,7 +102,8 @@ class DatabaseIntrospection(MysqlDatabaseIntrospection):
             info = field_info[line[0]]
             fields.append(
                 FieldInfo(
-                    *line[:3],
+                    *line[:2],
+                    to_int(info.max_len) or line[2],
                     to_int(info.max_len) or line[3],
                     to_int(info.num_prec) or line[4],
                     to_int(info.num_scale) or line[5],
@@ -111,6 +113,7 @@ class DatabaseIntrospection(MysqlDatabaseIntrospection):
                     info.extra,
                     info.is_unsigned,
                     line[0] in json_constraints,
+                    info.comment,
                 )
             )
         return fields

--- a/django_tidb/schema.py
+++ b/django_tidb/schema.py
@@ -26,11 +26,15 @@ class DatabaseSchemaEditor(MysqlDatabaseSchemaEditor):
         return "ALTER TABLE %(table)s CHANGE %(old_column)s %(new_column)s %(type)s"
 
     def skip_default_on_alter(self, field):
+        if self._is_limited_data_type(field):
+            # TiDB doesn't support defaults for BLOB/TEXT/JSON in the
+            # ALTER COLUMN statement.
+            return True
         return False
 
     @property
     def _supports_limited_data_type_defaults(self):
-        return True
+        return False
 
     def _field_should_be_indexed(self, model, field):
         return False

--- a/tidb_settings.py
+++ b/tidb_settings.py
@@ -13,21 +13,16 @@
 
 import os
 
-hosts = os.getenv('TIDB_HOST')
-if hosts is None:
-    hosts = "127.0.0.1"
-
-port = os.getenv('TIDB_PORT')
-if port is None:
-    port = 4000
+hosts = os.getenv('TIDB_HOST', '127.0.0.1')
+port = os.getenv('TIDB_PORT', 4000)
 
 DATABASES = {
     'default': {
         'ENGINE': 'django_tidb',
         'USER': 'root',
         'PASSWORD': '',
-        'HOST': '127.0.0.1',
-        'PORT': 4000,
+        'HOST': hosts,
+        'PORT': port,
         'TEST': {
             'NAME': 'django_tests',
             'CHARSET': 'utf8mb4',


### PR DESCRIPTION
## Feature
- Add `column_comment`  when introspecting table schema

## Fix
- TiDB doesn't support defaults for BLOB/TEXT/JSON in the ALTER COLUMN statement.
- Django 4.2.1 no longer supports MySQL 5.7, we need to explicitly declare the tidb_version in `get_database_version`
- Remove hard code in `tidb_settings.py`