### PR TITLE
fix: tidb does not support sql_create_column_inline_fk

### DIFF
--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -159,13 +159,6 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 "schema.tests.SchemaTests.test_add_inline_fk_update_data",
                 # This testcase is designed for MySQL only
                 "schema.tests.SchemaTests.test_add_foreign_key_quoted_db_table",
-                # Unsupported add column and foreign key in single statement
-                # https://github.com/pingcap/tidb/issues/45474
-                "schema.tests.SchemaTests.test_add_foreign_key_long_names",
-                # Ditto
-                "schema.tests.SchemaTests.test_unique_together_with_fk_with_existing_index",
-                # Ditto
-                "schema.tests.SchemaTests.test_add_inline_fk_index_update_data",
                 "schema.tests.SchemaTests.test_db_table",
                 "schema.tests.SchemaTests.test_indexes",
                 "schema.tests.SchemaTests.test_inline_fk",
@@ -232,9 +225,6 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 "migrations.test_operations.OperationTests.test_smallfield_bigautofield_foreignfield_growth",
                 # Unsupported modifying the Reorg-Data types on the primary key
                 "migrations.test_operations.OperationTests.test_alter_field_pk_fk",
-                # Unsupported add column and foreign key in single statement
-                # https://github.com/pingcap/tidb/issues/45474
-                "migrations.test_operations.OperationTests.test_remove_fk",
                 "migrations.test_loader.RecorderTests.test_apply",
                 "migrations.test_commands.MigrateTests.test_migrate_fake_initial",
                 "migrations.test_commands.MigrateTests.test_migrate_initial_false",

--- a/django_tidb/schema.py
+++ b/django_tidb/schema.py
@@ -17,6 +17,9 @@ from django.db.backends.mysql.schema import (
 
 
 class DatabaseSchemaEditor(MysqlDatabaseSchemaEditor):
+
+    sql_create_column_inline_fk = None
+
     @property
     def sql_delete_check(self):
         return "ALTER TABLE %(table)s DROP CHECK %(name)s"

--- a/django_tidb/schema.py
+++ b/django_tidb/schema.py
@@ -17,6 +17,8 @@ from django.db.backends.mysql.schema import (
 
 
 class DatabaseSchemaEditor(MysqlDatabaseSchemaEditor):
+    # Unsupported add column and foreign key in single statement
+    # https://github.com/pingcap/tidb/issues/45474
     sql_create_column_inline_fk = None
 
     @property

--- a/django_tidb/schema.py
+++ b/django_tidb/schema.py
@@ -17,7 +17,6 @@ from django.db.backends.mysql.schema import (
 
 
 class DatabaseSchemaEditor(MysqlDatabaseSchemaEditor):
-
     sql_create_column_inline_fk = None
 
     @property


### PR DESCRIPTION
fix https://github.com/pingcap/django-tidb/issues/40

TiDB related issue: https://github.com/pingcap/tidb/issues/45474

