### PR TITLE
fix: update _field_should_be_indexed

### DIFF
--- a/django_test_apps.txt
+++ b/django_test_apps.txt
@@ -1,3 +1,4 @@
+tidb
 admin_changelist
 admin_custom_urls
 admin_docs

--- a/django_test_suite.sh
+++ b/django_test_suite.sh
@@ -24,6 +24,7 @@ pip3 install -e .
 git clone --depth 1  --branch $DJANGO_VERSION https://github.com/django/django.git $DJANGO_TESTS_DIR/django
 cp tidb_settings.py $DJANGO_TESTS_DIR/django/tidb_settings.py
 cp tidb_settings.py $DJANGO_TESTS_DIR/django/tests/tidb_settings.py
+cp -r ./tests/ $DJANGO_TESTS_DIR/django/tests/tidb/
 
 cd $DJANGO_TESTS_DIR/django && pip3 install -e . && pip3 install -r tests/requirements/py3.txt && pip3 install -r tests/requirements/mysql.txt; cd ../../
 cd $DJANGO_TESTS_DIR/django/tests

--- a/django_tidb/schema.py
+++ b/django_tidb/schema.py
@@ -41,4 +41,11 @@ class DatabaseSchemaEditor(MysqlDatabaseSchemaEditor):
         return False
 
     def _field_should_be_indexed(self, model, field):
-        return False
+        if not field.db_index or field.unique:
+            return False
+        # No need to create an index for ForeignKey fields except if
+        # db_constraint=False because the index from that constraint won't be
+        # created.
+        if field.get_internal_type() == "ForeignKey" and field.db_constraint:
+            return False
+        return not self._is_limited_data_type(field)

--- a/tests/test_tidb_ddl.py
+++ b/tests/test_tidb_ddl.py
@@ -1,0 +1,54 @@
+from django.test import TransactionTestCase
+from django.test.utils import isolate_apps
+from django.db import models, connection
+
+
+class TiDBDDLTests(TransactionTestCase):
+    available_apps = ["tidb"]
+
+    def get_indexes(self, table):
+        """
+        Get the indexes on the table using a new cursor.
+        """
+        with connection.cursor() as cursor:
+            return [
+                c["columns"][0]
+                for c in connection.introspection.get_constraints(
+                    cursor, table
+                ).values()
+                if c["index"] and len(c["columns"]) == 1
+            ]
+
+    @isolate_apps("tidb")
+    def test_should_create_db_index(self):
+        # When define a model with db_index=True, TiDB should create a db index
+        class Tag(models.Model):
+            title = models.CharField(max_length=255, db_index=True)
+
+            class Meta:
+                app_label = "tidb"
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Tag)
+        self.assertIn("title", self.get_indexes("tidb_tag"))
+
+    @isolate_apps("tidb")
+    def test_should_create_db_index_for_foreign_key_with_no_db_constraint(self):
+        # When define a model with ForeignKey, TiDB should not create a db index
+        class Node1(models.Model):
+            title = models.CharField(max_length=255)
+
+            class Meta:
+                app_label = "tidb"
+
+        class Node2(models.Model):
+            node1 = models.ForeignKey(Node1, on_delete=models.CASCADE, db_constraint=False)
+
+            class Meta:
+                app_label = "tidb"
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Node1)
+            editor.create_model(Node2)
+        
+        self.assertIn("node1_id", self.get_indexes("tidb_node2"))


### PR DESCRIPTION
Fix: django-tidb does not create index when user defined it on field, for example `a = models.CharField(max_length=8, db_index=True)`

This PR also introduce how to create tests for django-tidb.