### PR TITLE
fix: add unique constraint after add field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,9 @@ jobs:
           # but it does not consider databases that do not support savepoints(TiDB < 6.2.0),
           # as a result, all `assertNumQueries` in test cases failed.
           # https://github.com/django/django/commit/798e38c2b9c46ab72e2ee8c33dc822f01b194b1e
-          - django-version: '4.2.4'
+          - django-version: '4.2.5'
             tidb-version: 'v4.0.15'
-          - django-version: '4.2.4'
+          - django-version: '4.2.5'
             tidb-version: 'v5.4.3'
 
     name: py${{ matrix.python-version }}_tidb${{ matrix.tidb-version }}_django${{ matrix.django-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - '3.10'
           - '3.11'
         django-version:
-          - '4.2.4'
+          - '4.2.5'
         tidb-version:
           - 'v7.1.1'
           - 'v6.5.3'

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -95,7 +95,7 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 "check_framework.test_database.DatabaseCheckTests.test_mysql_strict_mode",
                 # Unsupported add column and foreign key in single statement
                 "indexes.tests.SchemaIndexesMySQLTests.test_no_index_for_foreignkey",
-                # https://github.com/pingcap/django-tidb/issues/46
+                # TiDB does not support `JSON` format for `EXPLAIN ANALYZE`
                 "queries.test_explain.ExplainTests.test_mysql_analyze",
                 "queries.test_explain.ExplainTests.test_mysql_text_to_traditional",
                 # TiDB cannot guarantee to always rollback the main thread txn when deadlock occurs
@@ -125,10 +125,7 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                 "schema.tests.SchemaTests.test_ci_cs_db_collation",
                 # Unsupported drop integer primary key
                 "schema.tests.SchemaTests.test_primary_key",
-                "schema.tests.SchemaTests.test_indexes",
-                "schema.tests.SchemaTests.test_remove_db_index_doesnt_remove_custom_indexes",
                 "schema.tests.SchemaTests.test_add_auto_field",
-                "schema.tests.SchemaTests.test_add_field_o2o_nullable",
                 "schema.tests.SchemaTests.test_alter_autofield_pk_to_smallautofield_pk",
                 "schema.tests.SchemaTests.test_alter_primary_key_db_collation",
                 "schema.tests.SchemaTests.test_alter_primary_key_the_same_name",

--- a/run_testing_worker.py
+++ b/run_testing_worker.py
@@ -35,9 +35,11 @@ print("test apps: ", all_apps)
 if not all_apps:
     exit()
 
-exitcode = os.WEXITSTATUS(os.system(
-    """DJANGO_TEST_APPS="{apps}" bash ./django_test_suite.sh""".format(
-        apps=" ".join(all_apps)
+exitcode = os.WEXITSTATUS(
+    os.system(
+        """DJANGO_TEST_APPS="{apps}" bash ./django_test_suite.sh""".format(
+            apps=" ".join(all_apps)
+        )
     )
-))
+)
 exit(exitcode)

--- a/tests/test_tidb_ddl.py
+++ b/tests/test_tidb_ddl.py
@@ -19,6 +19,16 @@ class TiDBDDLTests(TransactionTestCase):
                 if c["index"] and len(c["columns"]) == 1
             ]
 
+    def get_uniques(self, table):
+        with connection.cursor() as cursor:
+            return [
+                c["columns"][0]
+                for c in connection.introspection.get_constraints(
+                    cursor, table
+                ).values()
+                if c["unique"] and len(c["columns"]) == 1
+            ]
+
     @isolate_apps("tidb")
     def test_should_create_db_index(self):
         # When define a model with db_index=True, TiDB should create a db index
@@ -31,6 +41,12 @@ class TiDBDDLTests(TransactionTestCase):
         with connection.schema_editor() as editor:
             editor.create_model(Tag)
         self.assertIn("title", self.get_indexes("tidb_tag"))
+
+        new_field = models.CharField(max_length=255, db_index=True)
+        new_field.set_attributes_from_name("new_field")
+        with connection.schema_editor() as editor:
+            editor.add_field(Tag, new_field)
+        self.assertIn("new_field", self.get_indexes("tidb_tag"))
 
     @isolate_apps("tidb")
     def test_should_create_db_index_for_foreign_key_with_no_db_constraint(self):
@@ -54,3 +70,22 @@ class TiDBDDLTests(TransactionTestCase):
             editor.create_model(Node2)
 
         self.assertIn("node1_id", self.get_indexes("tidb_node2"))
+
+    @isolate_apps("tidb")
+    def test_add_unique_field(self):
+        # issue: https://github.com/pingcap/django-tidb/issues/48
+        class Node3(models.Model):
+            title = models.CharField(max_length=255, unique=True)
+
+            class Meta:
+                app_label = "tidb"
+
+        with connection.schema_editor() as editor:
+            editor.create_model(Node3)
+        self.assertIn("title", self.get_uniques("tidb_node3"))
+
+        parent = models.OneToOneField(Node3, models.CASCADE)
+        parent.set_attributes_from_name("parent")
+        with connection.schema_editor() as editor:
+            editor.add_field(Node3, parent)
+        self.assertIn("parent_id", self.get_uniques("tidb_node3"))

--- a/tests/test_tidb_ddl.py
+++ b/tests/test_tidb_ddl.py
@@ -84,6 +84,12 @@ class TiDBDDLTests(TransactionTestCase):
             editor.create_model(Node3)
         self.assertIn("title", self.get_uniques("tidb_node3"))
 
+        new_field = models.CharField(max_length=255, unique=True)
+        new_field.set_attributes_from_name("new_field")
+        with connection.schema_editor() as editor:
+            editor.add_field(Node3, new_field)
+        self.assertIn("new_field", self.get_uniques("tidb_node3"))
+
         parent = models.OneToOneField(Node3, models.CASCADE)
         parent.set_attributes_from_name("parent")
         with connection.schema_editor() as editor:

--- a/tidb_settings.py
+++ b/tidb_settings.py
@@ -13,38 +13,38 @@
 
 import os
 
-hosts = os.getenv('TIDB_HOST', '127.0.0.1')
-port = os.getenv('TIDB_PORT', 4000)
+hosts = os.getenv("TIDB_HOST", "127.0.0.1")
+port = os.getenv("TIDB_PORT", 4000)
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django_tidb',
-        'USER': 'root',
-        'PASSWORD': '',
-        'HOST': hosts,
-        'PORT': port,
-        'TEST': {
-            'NAME': 'django_tests',
-            'CHARSET': 'utf8mb4',
-            'COLLATION': 'utf8mb4_general_ci',
+    "default": {
+        "ENGINE": "django_tidb",
+        "USER": "root",
+        "PASSWORD": "",
+        "HOST": hosts,
+        "PORT": port,
+        "TEST": {
+            "NAME": "django_tests",
+            "CHARSET": "utf8mb4",
+            "COLLATION": "utf8mb4_general_ci",
         },
     },
-    'other': {
-        'ENGINE': 'django_tidb',
-        'USER': 'root',
-        'PASSWORD': '',
-        'HOST': hosts,
-        'PORT': port,
-        'TEST': {
-            'NAME': 'django_tests2',
-            'CHARSET': 'utf8mb4',
-            'COLLATION': 'utf8mb4_general_ci',
+    "other": {
+        "ENGINE": "django_tidb",
+        "USER": "root",
+        "PASSWORD": "",
+        "HOST": hosts,
+        "PORT": port,
+        "TEST": {
+            "NAME": "django_tests2",
+            "CHARSET": "utf8mb4",
+            "COLLATION": "utf8mb4_general_ci",
         },
     },
 }
-DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 USE_TZ = False
-SECRET_KEY = 'django_tests_secret_key'
+SECRET_KEY = "django_tests_secret_key"
 
 # Use a fast hasher to speed up tests.
 PASSWORD_HASHERS = [

--- a/tox.ini
+++ b/tox.ini
@@ -31,9 +31,10 @@ setenv =
 
 [testenv:lint]
 skip_install = True
+allowlist_externals = bash
 deps =
   flake8==6.0.0
-  black==23.1.0
+  black==23.7.0
 commands =
-  flake8 --max-line-length 130 django_tidb tests
-  black --diff --check django_tidb tests
+  bash -c "flake8 --max-line-length 130 django_tidb tests *py"
+  bash -c "black --diff --check django_tidb tests *py"


### PR DESCRIPTION
fix https://github.com/pingcap/django-tidb/issues/48

TiDB does not support multiple operations with a single DDL statement. For more information, refer to the [MySQL Compatibility - DDL operations](https://docs.pingcap.com/tidb/dev/mysql-compatibility#ddl-operations) documentation. In django-tidb, we now separate the SQL into multiple DDL statements: first, add the column, and then add the unique constraint and foreign key.