### PR TITLE
fix: AUTO_RANDOM does not support define range before TiDB 6.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Migrate from `AUTO_INCREMENT` to `AUTO_RANDOM`:
 
 > **Note**
 >
-> `AUTO_RANDOM` is supported after TiDB v3.1.0, and only support define with `range` after v6.5.0, so `range` will be ignored if TiDB version is lower than v6.5.0
+> `AUTO_RANDOM` is supported after TiDB v3.1.0, and only support define with `range` after v6.3.0, so `range` will be ignored if TiDB version is lower than v6.3.0
 
 ### Using `AUTO_ID_CACHE`
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Migrate from `AUTO_INCREMENT` to `AUTO_RANDOM`:
 
 3. Finnaly, migrate it to `BigAutoRandomField(bigint)`.
 
+> **Note**
+>
+> `AUTO_RANDOM` is supported after TiDB v3.1.0, and only support define with `range` after v6.5.0, so `range` will be ignored if TiDB version is lower than v6.5.0
+
 ### Using `AUTO_ID_CACHE`
 
 [`AUTO_ID_CACHE`](https://docs.pingcap.com/tidb/stable/auto-increment#auto_id_cache) allow users to set the cache size for allocating the auto-increment ID, as you may know, TiDB guarantees that AUTO_INCREMENT values are monotonic (always increasing) on a per-server basis, but its value may appear to jump dramatically if an INSERT operation is performed against another TiDB Server, This is caused by the fact that each server has its own cache which is controlled by `AUTO_ID_CACHE`. But from TiDB v6.4.0, it introduces a centralized auto-increment ID allocating service, you can enable [*MySQL compatibility mode*](https://docs.pingcap.com/tidb/stable/auto-increment#mysql-compatibility-mode) by set `AUTO_ID_CACHE` to `1` when creating a table without losing performance.

--- a/django_tidb/base.py
+++ b/django_tidb/base.py
@@ -42,11 +42,6 @@ class DatabaseWrapper(MysqlDatabaseWrapper):
     introspection_class = DatabaseIntrospection
     ops_class = DatabaseOperations
 
-    data_types = {
-        **MysqlDatabaseWrapper.data_types,
-        "BigAutoRandomField": "bigint AUTO_RANDOM(%(shard_bits)s, %(range)s)",
-    }
-
     def get_database_version(self):
         return self.tidb_version
 

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -185,6 +185,17 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                     }
                 }
             )
+        if self.connection.tidb_version < (6, 5):
+            skips.update(
+                {
+                    "auto_random": {
+                        "tidb.test_tidb_auto_random.TiDBAutoRandomMigrateTests"
+                        ".test_create_table_explicit_auto_random_field_with_shard_bits_and_range",
+                        "tidb.test_tidb_auto_random.TiDBAutoRandomMigrateTests"
+                        ".test_create_table_explicit_auto_random_field_with_range",
+                    }
+                }
+            )
         if self.connection.tidb_version < (6, 6):
             skips.update(
                 {

--- a/django_tidb/features.py
+++ b/django_tidb/features.py
@@ -185,7 +185,7 @@ class DatabaseFeatures(MysqlDatabaseFeatures):
                     }
                 }
             )
-        if self.connection.tidb_version < (6, 5):
+        if self.connection.tidb_version < (6, 3):
             skips.update(
                 {
                     "auto_random": {

--- a/django_tidb/fields/__init__.py
+++ b/django_tidb/fields/__init__.py
@@ -79,3 +79,12 @@ class BigAutoRandomField(BigAutoField):
         if self.range is not None:
             kwargs["range"] = self.range
         return name, path, args, kwargs
+
+    def db_type(self, connection):
+        data = self.db_type_parameters(connection)
+        if connection.tidb_version < (6, 5):
+            # TiDB < 6.5 doesn't support define AUTO_RANDOM with range
+            data_type = "bigint AUTO_RANDOM(%(shard_bits)s)"
+        else:
+            data_type = "bigint AUTO_RANDOM(%(shard_bits)s, %(range)s)"
+        return data_type % data

--- a/django_tidb/fields/__init__.py
+++ b/django_tidb/fields/__init__.py
@@ -82,8 +82,8 @@ class BigAutoRandomField(BigAutoField):
 
     def db_type(self, connection):
         data = self.db_type_parameters(connection)
-        if connection.tidb_version < (6, 5):
-            # TiDB < 6.5 doesn't support define AUTO_RANDOM with range
+        if connection.tidb_version < (6, 3):
+            # TiDB < 6.3 doesn't support define AUTO_RANDOM with range
             data_type = "bigint AUTO_RANDOM(%(shard_bits)s)"
         else:
             data_type = "bigint AUTO_RANDOM(%(shard_bits)s, %(range)s)"

--- a/tests/test_tidb_auto_random.py
+++ b/tests/test_tidb_auto_random.py
@@ -175,9 +175,14 @@ class TiDBBigAutoRandomFieldTests(TestCase):
         rel_db_type = field.rel_db_type(connection)
         # Currently, We can't find a general way to get the auto_random info from the field.
         self.assertEqual(rel_db_type, "bigint")
-        self.assertEqual(
-            self.rel_db_type_class().db_type(connection), "bigint AUTO_RANDOM(5, 64)"
-        )
+        if connection.tidb_version < (6, 5):
+            self.assertEqual(
+                self.rel_db_type_class().db_type(connection), "bigint AUTO_RANDOM(5)"
+            )
+        else:
+            self.assertEqual(
+                self.rel_db_type_class().db_type(connection), "bigint AUTO_RANDOM(5, 64)"
+            )
 
 
 AUTO_RANDOM_PATTERN = re.compile(

--- a/tests/test_tidb_auto_random.py
+++ b/tests/test_tidb_auto_random.py
@@ -181,7 +181,8 @@ class TiDBBigAutoRandomFieldTests(TestCase):
             )
         else:
             self.assertEqual(
-                self.rel_db_type_class().db_type(connection), "bigint AUTO_RANDOM(5, 64)"
+                self.rel_db_type_class().db_type(connection),
+                "bigint AUTO_RANDOM(5, 64)",
             )
 
 

--- a/tests/test_tidb_auto_random.py
+++ b/tests/test_tidb_auto_random.py
@@ -175,7 +175,7 @@ class TiDBBigAutoRandomFieldTests(TestCase):
         rel_db_type = field.rel_db_type(connection)
         # Currently, We can't find a general way to get the auto_random info from the field.
         self.assertEqual(rel_db_type, "bigint")
-        if connection.tidb_version < (6, 5):
+        if connection.tidb_version < (6, 3):
             self.assertEqual(
                 self.rel_db_type_class().db_type(connection), "bigint AUTO_RANDOM(5)"
             )


### PR DESCRIPTION
TiDB before 6.3.0 does not support define `AUTO_RANDOM` with range, refer to [doc](https://docs.pingcap.com/tidb/v6.1/auto-random).
