### PR TITLE
release 4.2.3

### DIFF
--- a/django_tidb/__init__.py
+++ b/django_tidb/__init__.py
@@ -16,7 +16,7 @@
 
 from .patch import monkey_patch
 
-__version__ = "4.2.2"
+__version__ = "4.2.3"
 
 
 monkey_patch()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version"]
 "Source" = "https://github.com/pingcap/django-tidb"
 
 [tool.setuptools]
-packages = ["django_tidb"]
+packages = ["django_tidb", "django_tidb.fields"]
 
 [tool.setuptools.dynamic]
 version = {attr = "django_tidb.__version__"}


### PR DESCRIPTION
Update `pyproject.toml`, If you don't define `django_tidb.fields` in the `packages` at GitHub Action environment, it will be missing. However, it is fine if you don't define it locally.
