### PR TITLE
CI against TiDB 8.1.0 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
         django-version:
           - '5.0.4'
         tidb-version:
+          - 'v8.1.0'
           - 'v7.5.1'
           - 'v7.1.4'
           - 'v6.5.8'


### PR DESCRIPTION
This commit adds CI against TiDB 8.1.0 LTS because I want to see if django-tidb works with TiDB 8.1.0 LTS.