### PR TITLE
Use compatible release clause `~=` defined at PEP 440

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ To install django-tidb, you need to select the version that corresponds with you
 
 |django|django-tidb|install command|
 |:----:|:---------:|:-------------:|
-|v5.0.x|v5.0.x|`pip install 'django-tidb>=5.0.0,<5.1.0'`|
-|v4.2.x|v4.2.x|`pip install 'django-tidb>=4.2.0,<4.3.0'`|
-|v4.1.x|v4.1.x|`pip install 'django-tidb>=4.1.0,<4.2.0'`|
-|v3.2.x|v3.2.x|`pip install 'django-tidb>=3.2.0,<3.3.0'`|
+|v5.0.x|v5.0.x|`pip install 'django-tidb~=5.0.0'`|
+|v4.2.x|v4.2.x|`pip install 'django-tidb~=4.2.0'`|
+|v4.1.x|v4.1.x|`pip install 'django-tidb~=4.1.0'`|
+|v3.2.x|v3.2.x|`pip install 'django-tidb~=3.2.0'`|
 
 ## Usage
 


### PR DESCRIPTION
This pull request updates to Use compatible release clause `~=` defined at PEP 440. I prefer this syntax to the current one.

### How it works
```python
% python -V
Python 3.12.3
% pip -V
pip 24.2 from /Users/yahonda@pingcap.com/Desktop/my-project/.venv/lib/python3.12/site-packages/pip (python 3.12)
```

- `pip install 'django-tidb~=5.0.0'` installs the latest patch version of django-tidb 5.0.z that is [5.0.0](https://github.com/pingcap/django-tidb/releases/tag/5.0.0).
```python
% pip install 'django-tidb~=5.0.0'
Collecting django-tidb~=5.0.0
  Downloading django_tidb-5.0.0-py3-none-any.whl.metadata (9.1 kB)
Downloading django_tidb-5.0.0-py3-none-any.whl (24 kB)
Installing collected packages: django-tidb
Successfully installed django-tidb-5.0.0
```
- `pip install 'django-tidb~=4.2.0'` installs the latest patch version of django-tidb 4.2.z that is [4.2.4](https://github.com/pingcap/django-tidb/releases/tag/4.2.4)

```python
% pip install 'django-tidb~=4.2.0'
Collecting django-tidb~=4.2.0
  Downloading django_tidb-4.2.4-py3-none-any.whl.metadata (9.0 kB)
Downloading django_tidb-4.2.4-py3-none-any.whl (23 kB)
Installing collected packages: django-tidb
  Attempting uninstall: django-tidb
    Found existing installation: django-tidb 5.0.0
    Uninstalling django-tidb-5.0.0:
      Successfully uninstalled django-tidb-5.0.0
Successfully installed django-tidb-4.2.4
```

- `pip install 'django-tidb~=4.1.0'` installs the latest patch version of django-tidb 4.1.z that is [4.1.3](https://github.com/pingcap/django-tidb/releases/tag/4.1.3)
```python
% pip install 'django-tidb~=4.1.0'

Collecting django-tidb~=4.1.0
  Downloading django_tidb-4.1.3-py3-none-any.whl.metadata (7.5 kB)
Downloading django_tidb-4.1.3-py3-none-any.whl (24 kB)
Installing collected packages: django-tidb
  Attempting uninstall: django-tidb
    Found existing installation: django-tidb 4.2.4
    Uninstalling django-tidb-4.2.4:
      Successfully uninstalled django-tidb-4.2.4
Successfully installed django-tidb-4.1.3
%
```
- `pip install 'django-tidb~=3.2.0'` installs the latest patch version of django-tidb 4.1.z that is [3.2.3](https://github.com/pingcap/django-tidb/releases/tag/3.2.3)
```python
% pip install 'django-tidb~=3.2.0'
Collecting django-tidb~=3.2.0
  Downloading django_tidb-3.2.3-py3-none-any.whl.metadata (7.6 kB)
Downloading django_tidb-3.2.3-py3-none-any.whl (24 kB)
Installing collected packages: django-tidb
  Attempting uninstall: django-tidb
    Found existing installation: django-tidb 4.1.3
    Uninstalling django-tidb-4.1.3:
      Successfully uninstalled django-tidb-4.1.3
Successfully installed django-tidb-3.2.3
%
```

### References
https://peps.python.org/pep-0440/#compatible-release