### PR TITLE
Support adding vector index to the Database Model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,11 @@ jobs:
 
     name: vector-py${{ matrix.python-version }}_django${{ matrix.django-version }}
     runs-on: ubuntu-latest
-    env:
-      TIDB_HOST: ${{ secrets.SERVRLESS_TEST_TIDB_HOST }}
-      TIDB_USER: ${{ secrets.SERVRLESS_TEST_TIDB_USER }}
-      TIDB_PASSWORD: ${{ secrets.SERVRLESS_TEST_TIDB_PASSWORD }}
+    services:
+      tidb:
+        image: wangdi4zm/tind:v8.4.0-vector-index
+        ports:
+          - 4000:4000
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -164,11 +164,11 @@ You can also add an hnsw index when creating the table, for more information, pl
 
 ```python
 class Test(models.Model):
-    # Note:
-    #   - Using comment to add hnsw index is a temporary solution. In the future it will use `CREATE INDEX` syntax.
-    #   - Currently the hnsw index cannot be changed after the table has been created.
-    #   - Only Django >= 4.2 supports `db_comment`.
-    embedding = VectorField(dimensions=3, db_comment="hnsw(distance=l2)")
+    embedding = VectorField(dimensions=3)
+    class Meta:
+        indexes = [
+            VectorIndex(L2Distance("embedding"), name='idx_l2'),
+        ]
 ```
 
 #### Create a record

--- a/django_tidb/__init__.py
+++ b/django_tidb/__init__.py
@@ -16,7 +16,7 @@
 
 from .patch import monkey_patch
 
-__version__ = "5.0.0"
+__version__ = "5.0.1"
 
 
 monkey_patch()

--- a/django_tidb/fields/vector.py
+++ b/django_tidb/fields/vector.py
@@ -159,6 +159,11 @@ class VectorIndex(Index):
         distance=CosineDistance('embedding', [3, 1, 2])
     ).filter(distance__lt=5)
     ```
+
+    Note:
+    Creating a vector index will automatically set the "TiFlash replica" to 1 in TiDB.
+    If you want to use high-availability columnar storage feature, use raw SQL instead.
+
     """
 
     def __init__(

--- a/tests/tidb_vector/models.py
+++ b/tests/tidb_vector/models.py
@@ -1,6 +1,11 @@
 from django.db import models
 
-from django_tidb.fields.vector import VectorField
+from django_tidb.fields.vector import (
+    VectorField,
+    VectorIndex,
+    CosineDistance,
+    L2Distance,
+)
 
 
 class Document(models.Model):
@@ -11,3 +16,14 @@ class Document(models.Model):
 class DocumentExplicitDimension(models.Model):
     content = models.TextField()
     embedding = VectorField(dimensions=3)
+
+
+class DocumentWithAnnIndex(models.Model):
+    content = models.TextField()
+    embedding = VectorField(dimensions=3)
+
+    class Meta:
+        indexes = [
+            VectorIndex(CosineDistance("embedding"), name="idx_cos"),
+            VectorIndex(L2Distance("embedding"), name="idx_l2"),
+        ]

--- a/tests/tidb_vector/test_vector.py
+++ b/tests/tidb_vector/test_vector.py
@@ -9,7 +9,7 @@ from django_tidb.fields.vector import (
     NegativeInnerProduct,
 )
 
-from .models import Document, DocumentExplicitDimension
+from .models import Document, DocumentExplicitDimension, DocumentWithAnnIndex
 
 
 class TiDBVectorFieldTests(TestCase):
@@ -76,3 +76,7 @@ class TiDBVectorFieldTests(TestCase):
 
 class TiDBVectorFieldExplicitDimensionTests(TiDBVectorFieldTests):
     model = DocumentExplicitDimension
+
+
+class TiDBVectorFieldWithAnnIndexTests(TiDBVectorFieldTests):
+    model = DocumentWithAnnIndex


### PR DESCRIPTION
## What's changed
* Introduce class VectorIndex and overwrite the `create_sql` for building the SQL of `CREATE VECTOR INDEX ... ON ...`
* Support using `L1Distance`/`L2Distance`/`CosineDistance`/`NegativeInnerProduct` as expression index
* Bump the version from 5.0.0 to 5.0.1, so that other libraries can update their requirements version to get the vector index definition